### PR TITLE
make sure you return the new hashes

### DIFF
--- a/nested.rb
+++ b/nested.rb
@@ -15,7 +15,7 @@ def hopper
           :languages => ["C"]
         }
      }
-
+programmer_hash[:grace_hopper]
 
 end
 
@@ -37,6 +37,7 @@ def alan_kay_is_known_for
           :languages => ["C"]
         }
      }
+  programmer_hash[:alan_kay][:known_for]
 end
 
 def dennis_ritchies_language
@@ -52,9 +53,10 @@ def dennis_ritchies_language
         },
         :dennis_ritchie => {
           :known_for => "Unix",
-          :languages => ["C"]
+          :languages => "C"
         }
      }
+     programmer_hash[:dennis_ritchie][:languages]
 end
 
 def adding_matz
@@ -77,7 +79,11 @@ def adding_matz
         :dennis_ritchie => {
           :known_for => "Unix",
           :languages => ["C"]
-        }
+        },
+        :yukihiro_matsumoto => {
+          :known_for => "Ruby",
+          :languages => ["LISP , C"]
+        }    
      }
 
     
@@ -99,10 +105,9 @@ def changing_alan
           :languages => ["C"]
         }
      }
-     #change what Alan Kay is :known_for the value of the alans_new_info variable. 
      alans_new_info = "GUI"
-     
-     
+     programmer_hash[:alan_kay][:known_for] = alans_new_info
+     programmer_hash   
 end
 
 def adding_to_dennis
@@ -121,7 +126,8 @@ def adding_to_dennis
           :languages => ["C"]
         }
      }
-
+  programmer_hash[:dennis_ritchie][:languages] = ["C", "Assembly"]
+  programmer_hash
      
 end
 


### PR DESCRIPTION
A little more advanced, this time I as controlling the return values of the hashes I was operating on.

I became stuck momentarily on the last two tests with this code: 
```

def changing_alan
	programmer_hash = 
 		{
        :grace_hopper => {
          :known_for => "COBOL",
          :languages => ["COBOL", "FORTRAN"]
        },
        :alan_kay => {
          :known_for => "Object Orientation",
          :languages => ["Smalltalk", "LISP"]
        },
        :dennis_ritchie => {
          :known_for => "Unix",
          :languages => ["C"]
        }
     }
     alans_new_info = "GUI"
     programmer_hash[:alan_kay][:known_for] = alans_new_info 
end

def adding_to_dennis
	programmer_hash = 
 		{
        :grace_hopper => {
          :known_for => "COBOL",
          :languages => ["COBOL", "FORTRAN"]
        },
        :alan_kay => {
          :known_for => "Object Orientation",
          :languages => ["Smalltalk", "LISP"]
        },
        :dennis_ritchie => {
          :known_for => "Unix",
          :languages => ["C"]
        }
     }
  programmer_hash[:dennis_ritchie][:languages] = ["C", "Assembly"]
     
end
```
Getting this error: 
```
  1) nested hash #changing_alan operates on the programmer_hash and changes what Alan Kay is known for, returning the newly-changed hash
     Failure/Error: expect(changing_alan[:alan_kay][:known_for]).to eq("GUI")
     TypeError:
       no implicit conversion of Symbol into Integer
     # ./spec/nested_spec.rb:32:in `[]'
     # ./spec/nested_spec.rb:32:in `block (3 levels) in <top (required)>'

  2) nested hash #adding_to_dennis operates on the programmer_hash and adds 'Assembly' to Dennis Ritchie's languages, returning the newly-added-to-hash
     Failure/Error: expect(adding_to_dennis[:dennis_ritchie][:languages]).to include("Assembly")
     TypeError:
       no implicit conversion of Symbol into Integer
     # ./spec/nested_spec.rb:38:in `[]'
     # ./spec/nested_spec.rb:38:in `block (3 levels) in <top (required)>'
```
So what was going on was that I was not calling the `programmer_hash` hash again after I changed the information in both of them. If I simply added a final `programmer_hash` to the end of the `changing_alan` and `adding_to_dennis` methods the tests ended up passing. I was operating off the assumption of an implicit return with the final lines of code in the methods above, and that wasn't working. Figured it out in due course, but it was sure scary having two questions open in Learn.co for a while.